### PR TITLE
build_script_template: Add TEMPLATECONF generic and hmx

### DIFF
--- a/scripts/build_script_template
+++ b/scripts/build_script_template
@@ -66,7 +66,11 @@ init_build()
 	fi
 
 	POKYFOLDER="sources/poky"
-	export TEMPLATECONF=${PWD}/sources/meta-mobility-poky-distro/conf 
+	if [[ $MACHINE == imx8mp-var-dart-hmx1 ]]; then
+		export TEMPLATECONF=${PWD}/sources/meta-mobility-poky-distro/conf/hmx 
+	else
+		export TEMPLATECONF=${PWD}/sources/meta-mobility-poky-distro/conf/generic 
+	fi
 	source $POKYFOLDER/oe-init-build-env "$1"
 	# Set Downloads folder in conf/local.conf if $DL_DIR is a folder and not yet set
 	if [[ -d $DL_DIR ]]; then 


### PR DESCRIPTION
This script will now select sourcing the local.conf and bblayers.conf depending on the machine. Te reason is that hmx machines can change how mxv (mx5) and mx4 is built.