### PR TITLE
kirkstone: update mobility distro: add meta-filesystems

### DIFF
--- a/kirkstone.xml
+++ b/kirkstone.xml
@@ -24,7 +24,7 @@
   <project revision="f02882e2aa9279ca7becca8d0cedbffe88b5a253" remote="python2" upstream="kirkstone"   name="meta-python2"            path="sources/meta-python2"/>
 
   <project revision="acd0ab4a09e72e9b07590a09ccf9fddfd69ca036" remote="hm"  name="meta-hostmobility-bsp" path="sources/meta-hostmobility-bsp" />
-  <project revision="74d57e810b44a7f569a8fdb99c41e0120a9f309b" remote="hm"  name="meta-mobility-poky-distro" path="sources/meta-mobility-poky-distro" />
+  <project revision="93d093911e21795134f9387da8163cd50617cbdd" remote="hm"  name="meta-mobility-poky-distro" path="sources/meta-mobility-poky-distro" />
   <project revision="502be8134cd55d4d3646f43f47fd2d6b233c71bf" remote="hmssh" name="mx4-deploy.git" path="mx4-deploy" />
   
   <project revision="2d08d6bf376a1e06c53164fd6283b03ec2309da4" remote="clang" name="meta-clang" path="sources/meta-clang" />

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -311,15 +311,27 @@ EOF
   docker_exit_code=$?
 
   # Copy created e.g. release tar.gz that include *_hmupdate.img back to Yocto deploy dir to keep them.
-  hmupdate_archive=build/tmp/deploy/images/"${MACHINE}/hmupdate-${image}"
-  [[ -d "$hmupdate_archive" ]]
-    rm -r "$hmupdate_archive" \
-    || return 1
+  hmupdate_archive="$YOCTO_FOLDER/build/tmp/deploy/images/${MACHINE}/hmupdate-${image}"
+  if [[ -d "$hmupdate_archive" ]]; then
+    rm -r "$hmupdate_archive"
+    if (( $? != 0 )); then
+      >&2 echo "🔴 Error in ${FUNCNAME[0]} Failed to remove directory $hmupdate_archive"
+      return 1
+    fi
+  fi
 
-  [[ -d "$hmupdate_archive" ]] || mkdir "$hmupdate_archive"
-  cp \
-    mx4-deploy/deploy-mx4-${short_machine}/release/*.tar.gz "${hmupdate_archive}/" \
-    || return 1
+  if [[ ! -d "$hmupdate_archive" ]]; then
+    mkdir "$hmupdate_archive"
+    if (( $? != 0 )); then
+      >&2 echo "🔴 Error in ${FUNCNAME[0]} Failed to create directory $hmupdate_archive"
+      return 1
+    fi
+  fi
+  cp "$YOCTO_FOLDER"/mx4-deploy/deploy-mx4-"${short_machine}"/release/*.tar.gz "${hmupdate_archive}/"
+  if (( $? != 0 )); then
+    >&2 echo "🔴 Error in ${FUNCNAME[0]} Failed to copy $YOCTO_FOLDER/mx4-deploy/deploy-mx4-${short_machine}/release/*.tar.gz to $hmupdate_archive"
+    return 1
+  fi
 
   return $docker_exit_code
 }

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -265,6 +265,7 @@ create_hm_update_image()
 {
   echo "☕ Creating update image $image for $MACHINE"
   short_machine="$(get_short_machine_name)"
+  build_folder=$(get_build_folder "${wanted_build_folder}")
   cd "$YOCTO_FOLDER"
 
   # Allow hostmobility/buildplatform-mx4:2.0, which runs as uid = 1000 to write
@@ -280,8 +281,7 @@ cd mx4-deploy
 # Clean up old directories. make_system.sh requires it!
 sudo rm -rf deploy-*
 
-DEPLOY_DIR=../build/tmp/deploy/images/$MACHINE
-
+DEPLOY_DIR=../${BUILD_FOLDER}/tmp/deploy/images/$MACHINE
 if [[ "$SHORT_MACHINE" == "c61" ]]; then
   root_filesystem=$DEPLOY_DIR/${TARGET_IMAGE}-${MACHINE}.tar.xz
   dtb=$(find $DEPLOY_DIR/ -name "vf61*-${MACHINE}.dtb")
@@ -305,6 +305,7 @@ EOF
       -e SHORT_MACHINE="$short_machine" \
       -e TARGET_IMAGE="$image" \
       -e BUILD_TAG="$BUILD_TAG" \
+      -e BUILD_FOLDER=$build_folder
       hostmobility/buildplatform-mx4:2.0 \
       bash ./build_mx4-v2.sh
 

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -282,6 +282,14 @@ cd mx4-deploy
 sudo rm -rf deploy-*
 
 DEPLOY_DIR=../${BUILD_FOLDER}/tmp/deploy/images/$MACHINE
+
+#Remove extra dtb symlink for example *-mx4-t30-mx4-t30.dtb so only *-mx4-t30.dtb is left.
+dtb=$(find $DEPLOY_DIR/ -name "*-${1}-${1}.dtb")
+if [ -n "$dtb" ]; then
+  rm "$dtb"
+fi
+#Now there should be only target dtb name left(symlink).
+
 if [[ "$SHORT_MACHINE" == "c61" ]]; then
   root_filesystem=$DEPLOY_DIR/${TARGET_IMAGE}-${MACHINE}.tar.xz
   dtb=$(find $DEPLOY_DIR/ -name "vf61*-${MACHINE}.dtb")
@@ -305,7 +313,7 @@ EOF
       -e SHORT_MACHINE="$short_machine" \
       -e TARGET_IMAGE="$image" \
       -e BUILD_TAG="$BUILD_TAG" \
-      -e BUILD_FOLDER=$build_folder
+      -e BUILD_FOLDER="$build_folder" \
       hostmobility/buildplatform-mx4:2.0 \
       bash ./build_mx4-v2.sh
 


### PR DESCRIPTION
This update 1) adds meta-filesystems which is a dependency for
meta-virtualization; 2) enables distro features virtualization and kvm
for both generic and hmx config.