### PR TITLE
bygg: remove buil tag from deploy mx4 image docker

### DIFF
--- a/scripts/bygg
+++ b/scripts/bygg
@@ -315,7 +315,6 @@ EOF
       -e MACHINE="$MACHINE" \
       -e SHORT_MACHINE="$short_machine" \
       -e TARGET_IMAGE="$image" \
-      -e BUILD_TAG="$BUILD_TAG" \
       -e BUILD_FOLDER="$build_folder" \
       hostmobility/buildplatform-mx4:2.0 \
       bash ./build_mx4-v2.sh


### PR DESCRIPTION
There is no use for it the build has already been taged.