### PR TITLE
Support em05 v2 and clean up Hostmobility console image

### DIFF
--- a/kirkstone.xml
+++ b/kirkstone.xml
@@ -25,7 +25,7 @@
 
   <project revision="f02882e2aa9279ca7becca8d0cedbffe88b5a253" remote="python2" upstream="kirkstone"   name="meta-python2"            path="sources/meta-python2"/>
 
-  <project revision="9a13cbda7561c74c0f44126083c2a4eb32aec479" remote="hm" name="meta-hostmobility-bsp" path="sources/meta-hostmobility-bsp" />
+  <project revision="eec80c9e0426a743158f039673618ebb65b0e0ec" remote="hm" name="meta-hostmobility-bsp" path="sources/meta-hostmobility-bsp" />
   <project revision="9a13cbda7561c74c0f44126083c2a4eb32aec479" remote="hm" name="meta-mobility-poky-distro" path="sources/meta-mobility-poky-distro" />
   <project revision="502be8134cd55d4d3646f43f47fd2d6b233c71bf" remote="hmssh" name="mx4-deploy.git" path="mx4-deploy" />
   

--- a/kirkstone.xml
+++ b/kirkstone.xml
@@ -25,8 +25,8 @@
 
   <project revision="f02882e2aa9279ca7becca8d0cedbffe88b5a253" remote="python2" upstream="kirkstone"   name="meta-python2"            path="sources/meta-python2"/>
 
-  <project revision="e04d58b2196dd734596af71cf01b14ae875e1fda" remote="hm" name="meta-hostmobility-bsp" path="sources/meta-hostmobility-bsp" />
-  <project revision="747c4b4f978ca27eead5fc2f3f254b5f18fd62ef" remote="hm" name="meta-mobility-poky-distro" path="sources/meta-mobility-poky-distro" />
+  <project revision="9a13cbda7561c74c0f44126083c2a4eb32aec479" remote="hm" name="meta-hostmobility-bsp" path="sources/meta-hostmobility-bsp" />
+  <project revision="9a13cbda7561c74c0f44126083c2a4eb32aec479" remote="hm" name="meta-mobility-poky-distro" path="sources/meta-mobility-poky-distro" />
   <project revision="502be8134cd55d4d3646f43f47fd2d6b233c71bf" remote="hmssh" name="mx4-deploy.git" path="mx4-deploy" />
   
   <project revision="312ff1c39b1bf5d35c0321e873417eb013cea477" remote="clang" name="meta-clang" path="sources/meta-clang" />


### PR DESCRIPTION
BSP changes:
- HMX: support new EM05(V2) USB connection id

Distro changes:
- packagegroup-hostmobility-base: add sudo
- Console-hostmobility-image: move python3 Image installs to packagegroup
- Console-hostmobility-image: add ssh-agent and ssh-add
- HMM: add extra tools to console image
- host-modem-m: remove COMPATIBLE_MACHINE restriction
- Update host-modem-m to work with a generic wvdail.conf
- recipies-support: bbk-cli: Fix license name
- PRODUCTION: console-image-robotframework.bb add dfu-util
- recipies-support: Add Bredbandskollen CLI