### PR TITLE
bygg: Add check write permission on deploy-images location before build images

### DIFF
--- a/scripts/bygg
+++ b/scripts/bygg
@@ -528,7 +528,7 @@ if [[ "$RUNNING_IN_DOCKER" != "1" ]]; then
 
   # Check destination and access to that location is ok before build the whole image
   if [[ -n "$image_server" ]]; then
-    echo  "⏳Check destination and access to that location is ok before build the whole image"
+    echo  "⏳Check destination and access before building the whole image"
     check_deploy_location "$YOCTO_FOLDER" "$image_server" "$img_includes"
 
     if [ $? -ne 0 ]; then

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -536,7 +536,7 @@ if [[ "$RUNNING_IN_DOCKER" != "1" ]]; then
       exit 1
     fi
   fi
-  # Start build image(s)
+  # Start building image(s)
   docker_args+=("$CONTAINER_NAME")
   docker_args+=("$SCRIPT_NAME" "$@")
   docker "${docker_args[@]}" || { echo "🔴 docker ${docker_args[*]} failed" ; exit 1 ; }

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -526,7 +526,6 @@ if [[ "$RUNNING_IN_DOCKER" != "1" ]]; then
     done
   fi
 
-  # Check destination and access to that location is ok before build the whole image
   if [[ -n "$image_server" ]]; then
     echo  "⏳Check destination and access before building the whole image"
     check_deploy_location "$YOCTO_FOLDER" "$image_server" "$img_includes"

--- a/scripts/bygg
+++ b/scripts/bygg
@@ -416,7 +416,7 @@ sync_packages()
   return 0
 }
 
-sync_images()
+check_deploy_location()
 {
   if [[ -z $1 ]]; then
     >&2 echo "🔴 Error in ${FUNCNAME[0]} sync packages yocto folder needed as first argument"
@@ -428,6 +428,24 @@ sync_images()
     return 1
   fi
 
+  IFS=":" read -ra destination_parts <<< "$2"
+  if [[ -n ${destination_parts[1]} ]]; then
+      ssh "${destination_parts[0]}" "[[ -w \"${destination_parts[1]}\" || -w \"\$(dirname \"${destination_parts[1]}\")\" ]]" || {
+          echo "Error: No write permission on ${destination_parts[1]}"
+          return 1
+      }
+  else
+      [[ -w "${destination_parts[0]}" || -w "$(dirname "${destination_parts[0]}")" ]] || {
+          echo "Error: No write permission on ${destination_parts[0]}"
+          return 1
+      }
+  fi
+
+  return 0
+}
+
+sync_images()
+{
   # Create destination directory. Interpret part before an eventual ":" as
   # a server name so run mkdir using ssh in that case.
   IFS=":" read  -ra destination_parts <<< "$2"
@@ -508,6 +526,17 @@ if [[ "$RUNNING_IN_DOCKER" != "1" ]]; then
     done
   fi
 
+  # Check destination and access to that location is ok before build the whole image
+  if [[ -n "$image_server" ]]; then
+    echo  "⏳Check destination and access to that location is ok before build the whole image"
+    check_deploy_location "$YOCTO_FOLDER" "$image_server" "$img_includes"
+
+    if [ $? -ne 0 ]; then
+      echo "🔴 check_deploy_location for deploy-images (${image_server}) failed, check additional output before this."
+      exit 1
+    fi
+  fi
+  # Start build image(s)
   docker_args+=("$CONTAINER_NAME")
   docker_args+=("$SCRIPT_NAME" "$@")
   docker "${docker_args[@]}" || { echo "🔴 docker ${docker_args[*]} failed" ; exit 1 ; }


### PR DESCRIPTION
Test performed using these parameters(ssh to hmx unit)
```
export BUILD_COMMAND=''; scripts/bygg  --delete-conf --manifest-file kirkstone-next.xml --machine verdin-am62-hmm --image console-hostmobility-image  --build-tag test1  --deploy-images . --deploy-image-includes '*.manifest,*.scr,*.tar.gz,*.wic.gz'
```
```
export BUILD_COMMAND=''; scripts/bygg  --delete-conf --manifest-file kirkstone-next.xml --machine verdin-am62-hmm --image console-hostmobility-image  --build-tag test1  --deploy-images root@192.168.128.135:test_deploy --deploy-image-includes '*.manifest,*.scr,*.tar.gz,*.wic.gz'
```