### PR TITLE
kirkstone-c1: bump revision of distro

### DIFF
--- a/kirkstone-c1.xml
+++ b/kirkstone-c1.xml
@@ -7,7 +7,7 @@
   
   <include name="kirkstone.xml" />
 
-  <project revision="3d746677a91bc558dc44379f5d3e75c38a654757" remote="hm" name="meta-mobility-c1-distro" path="sources/meta-mobility-c1-distro"/>
+  <project revision="9984aa1e2059ffdcabee68e30a70bb44ea1f3491" remote="hm" name="meta-mobility-c1-distro" path="sources/meta-mobility-c1-distro"/>
 </manifest>
 
 


### PR DESCRIPTION
This includes a u-boot configuration that disables boot interruption by key press.