### PR TITLE
scarthgap: hmm: Update Linux kernel to v6.6.129

### DIFF
--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -44,7 +44,7 @@
   <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="852dc54e325d37476482677aee309b0923412be1" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="3e1311ec106758d87eaa6e39143f5a640c6e5a3a" upstream="scarthgap-7.x.y"/>
-  <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="9d660de6b2ddae5ca2f3077ed9ec85243305725a" upstream="scarthgap-7.x.y"/>
+  <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="7f69c95aee5a2e1ac9b4a5aa54f04403f6535e00" upstream="scarthgap-7.x.y"/>
   <!-- Variscite SOM support -->
   <project name="meta-variscite-bsp-common"   remote="variscite"      path="sources/meta-variscite-bsp-common"  revision="4713e95f2c92d041f32c9835e32d701a876b02d8" upstream="scarthgap_6.6.52-2.2.0_var01"/>
   <project name="meta-variscite-bsp-imx"      remote="variscite"      path="sources/meta-variscite-bsp-imx"     revision="d87593ff52152909b4ded866918264a42f0a2d5e" upstream="scarthgap_6.6.52-2.2.0_var01"/>


### PR DESCRIPTION
Update the meta-toradex-ti layer which pulls in Linux v6.6.129.