### PR TITLE
scarthgap.xml: Update meta-hostmobility-bsp layer

### DIFF
--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -40,7 +40,7 @@
   <!-- ARM architecture support -->
   <project name="meta-arm"                    remote="yocto"          path="sources/meta-arm"                   revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" upstream="scarthgap"/>
   <!-- Host Mobility specific BSP and distro -->
-  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="d43db3bb8511c2b3db9d83010d6f5dfb59a055e9" upstream="main"/>
+  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="2ab8985c929e547562fec6499bdb50ca9e582289" upstream="main"/>
   <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="852dc54e325d37476482677aee309b0923412be1" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="3e1311ec106758d87eaa6e39143f5a640c6e5a3a" upstream="scarthgap-7.x.y"/>

--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -40,7 +40,7 @@
   <!-- ARM architecture support -->
   <project name="meta-arm"                    remote="yocto"          path="sources/meta-arm"                   revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" upstream="scarthgap"/>
   <!-- Host Mobility specific BSP and distro -->
-  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="2ab8985c929e547562fec6499bdb50ca9e582289" upstream="main"/>
+  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="aba25eaf9e9f6e2d79bcfd176687e656209aef11" upstream="main"/>
   <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="852dc54e325d37476482677aee309b0923412be1" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="3e1311ec106758d87eaa6e39143f5a640c6e5a3a" upstream="scarthgap-7.x.y"/>


### PR DESCRIPTION
# Update meta-hostmobility-bsp layer

The first commit includes:
- [Host-watchdog: update to version 2.1.0](https://github.com/hostmobility/meta-hostmobility-bsp/commit/2ab8985c929e547562fec6499bdb50ca9e582289)
- [hmx: host-watchdog-fw: Bump revision to 1.6](https://github.com/hostmobility/meta-hostmobility-bsp/commit/38ff5710b418af55a6d91acfb118461512caf3cc)

The second commit includes:
- [HMX: change linux kernel to 6.6.119](https://github.com/hostmobility/meta-hostmobility-bsp/commit/aba25eaf9e9f6e2d79bcfd176687e656209aef11)

The reason for separating them is to more easily test the changes in separate builds.