### PR TITLE
scarthgap: hmm: Update Linux kernel to v6.6.138

### DIFF
--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -43,8 +43,8 @@
   <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="d1a67a5ac173d93f48c7a882ed8b70802bcb8759" upstream="main"/>
   <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="852dc54e325d37476482677aee309b0923412be1" upstream="master"/>
   <!-- Toradex SOM support -->
-  <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="3e1311ec106758d87eaa6e39143f5a640c6e5a3a" upstream="scarthgap-7.x.y"/>
-  <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="7f69c95aee5a2e1ac9b4a5aa54f04403f6535e00" upstream="scarthgap-7.x.y"/>
+  <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="dd56c35bd3ba55f1dedc022cf13ec906e0ddb1f3" upstream="scarthgap-7.x.y"/>
+  <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="eb078c659fa9326a78ab2d3d88e99f9101e51a55" upstream="scarthgap-7.x.y"/>
   <!-- Variscite SOM support -->
   <project name="meta-variscite-bsp-common"   remote="variscite"      path="sources/meta-variscite-bsp-common"  revision="4713e95f2c92d041f32c9835e32d701a876b02d8" upstream="scarthgap_6.6.52-2.2.0_var01"/>
   <project name="meta-variscite-bsp-imx"      remote="variscite"      path="sources/meta-variscite-bsp-imx"     revision="d87593ff52152909b4ded866918264a42f0a2d5e" upstream="scarthgap_6.6.52-2.2.0_var01"/>


### PR DESCRIPTION
Update the layers below to bump the HMM kernel to v6.6.138:
- meta-toradex-bsp-common
- meta-toradex-ti

This addresses several security vulnerabilities, including CVE-2026-31431.