### PR TITLE
scarthgap, scarthgap-c2: update BSP layer and libgpiod config

### DIFF
--- a/scarthgap-c2.xml
+++ b/scarthgap-c2.xml
@@ -8,6 +8,6 @@
   <include name="scarthgap.xml" />
   <remove-project name="meta-mobility-poky-distro"/>
 
-  <project revision="11cc613d779f6837f9036a16e8848b1ca4e112d1" remote="hmssh" name="meta-mobility-c2-distro" path="sources/meta-mobility-c2-distro"/>
+  <project revision="08dfd3c1d0b4766770b5f7a77bc2dca9a774fd87" remote="hmssh" name="meta-mobility-c2-distro" path="sources/meta-mobility-c2-distro"/>
 
 </manifest>

--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -40,8 +40,8 @@
   <!-- ARM architecture support -->
   <project name="meta-arm"                    remote="yocto"          path="sources/meta-arm"                   revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" upstream="scarthgap"/>
   <!-- Host Mobility specific BSP and distro -->
-  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="d1a67a5ac173d93f48c7a882ed8b70802bcb8759" upstream="main"/>
-  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="852dc54e325d37476482677aee309b0923412be1" upstream="master"/>
+  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="e71db22f657b299befa9b6ab1228e41167e61f48" upstream="main"/>
+  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="453da18da61a653d8a8bf3c65d4520673ddcfea9" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="3e1311ec106758d87eaa6e39143f5a640c6e5a3a" upstream="scarthgap-7.x.y"/>
   <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="7f69c95aee5a2e1ac9b4a5aa54f04403f6535e00" upstream="scarthgap-7.x.y"/>


### PR DESCRIPTION
scarthgap:
 - meta-hostmobility-bsp:
   - hmm: host-watchdog-fw-am62x: Bump revision to 1.6
   - hmm: Add device tree V11
 - meta-mobility-poky-distro:
   - HMX, MXV, generic: conf: Remove preferred version of libgpiod

scarthgap-c2:
  - meta-mobility-c2-distro:
    - conf: Remove preferred version of libgpiod