### PR TITLE
scarthgap: Update meta-mobility-poky-distro

### DIFF
--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -41,7 +41,7 @@
   <project name="meta-arm"                    remote="yocto"          path="sources/meta-arm"                   revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" upstream="scarthgap"/>
   <!-- Host Mobility specific BSP and distro -->
   <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="e71db22f657b299befa9b6ab1228e41167e61f48" upstream="main"/>
-  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="453da18da61a653d8a8bf3c65d4520673ddcfea9" upstream="master"/>
+  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="4a181c28a855f720eeb5ede938c6919abd71aa93" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="dd56c35bd3ba55f1dedc022cf13ec906e0ddb1f3" upstream="scarthgap-7.x.y"/>
   <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="eb078c659fa9326a78ab2d3d88e99f9101e51a55" upstream="scarthgap-7.x.y"/>


### PR DESCRIPTION
This includes:
  - host-modem-m: Add verdin-am62 and update scripts for libgpiod v2.1 compatibility