### PR TITLE
scarthgap: update hostmobility BSP and poky-distro layers

### DIFF
--- a/scarthgap.xml
+++ b/scarthgap.xml
@@ -40,8 +40,8 @@
   <!-- ARM architecture support -->
   <project name="meta-arm"                    remote="yocto"          path="sources/meta-arm"                   revision="a81c19915b5b9e71ed394032e9a50fd06919e1cd" upstream="scarthgap"/>
   <!-- Host Mobility specific BSP and distro -->
-  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="e71db22f657b299befa9b6ab1228e41167e61f48" upstream="main"/>
-  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="fc2cbe39f69777732d05ae93c1bdf613cbcd1836" upstream="master"/>
+  <project name="meta-hostmobility-bsp"       remote="hmssh"          path="sources/meta-hostmobility-bsp"      revision="3f10c9ec3232fd292f6fdf48f060c9ebe7efeb70" upstream="main"/>
+  <project name="meta-mobility-poky-distro"   remote="hmssh"          path="sources/meta-mobility-poky-distro"  revision="3e81f6194773ce4cecb831ec70a384f1b0add1d3" upstream="master"/>
   <!-- Toradex SOM support -->
   <project name="meta-toradex-bsp-common.git" remote="tdx"            path="sources/meta-toradex-bsp-common"    revision="dd56c35bd3ba55f1dedc022cf13ec906e0ddb1f3" upstream="scarthgap-7.x.y"/>
   <project name="meta-toradex-ti.git"         remote="tdx"            path="sources/meta-toradex-ti"            revision="eb078c659fa9326a78ab2d3d88e99f9101e51a55" upstream="scarthgap-7.x.y"/>


### PR DESCRIPTION
BSP changes:
- hmm: defconfig: Fix autofs config name
- defconfig: add qmi support
- gpio-modem-controller: v2: Change optional regulator warn print to debug

Distro changes:
- recipes-core: Add some basic fallback for systemd-timesyncd
- networkmanager: update networkmanager and install connection-profiles
- modemmanager: add auto-enable
- hmm: systemd: Add custom journald.conf that limits /run use
- images: add a dedicated image for modem connectivity with networkmanager/modemmanager
- hmm: power on modem when modem manager is used